### PR TITLE
Make + sign optional

### DIFF
--- a/src/KenyaMobileFullRule.php
+++ b/src/KenyaMobileFullRule.php
@@ -9,7 +9,7 @@ class KenyaMobileFullRule implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! preg_match(pattern: '/^\+?254[17][0-9]{8}$/', subject: $value)) {
+        if (! is_string($value) || ! preg_match(pattern: '/^\+?254[17][0-9]{8}$/', subject: $value)) {
             $fail(trans(key: 'kenya-mobile::kenya-mobile.phone_full'));
         }
     }

--- a/src/KenyaMobileFullRule.php
+++ b/src/KenyaMobileFullRule.php
@@ -9,7 +9,7 @@ class KenyaMobileFullRule implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! preg_match(pattern: '/^254[17][0-9]{8}$/', subject: $value)) {
+        if (! preg_match(pattern: '/^\+?254[17][0-9]{8}$/', subject: $value)) {
             $fail(trans(key: 'kenya-mobile::kenya-mobile.phone_full'));
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kenyan mobile phone validation to accept an optional leading "+" and to only validate string inputs, reducing false validation errors while keeping existing error messaging unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->